### PR TITLE
Change node version to nodejs8.10

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ EOF
 resource "aws_lambda_function" "demo_lambda" {
 	function_name = "demo_lambda"
 	handler = "index.handler"
-	runtime = "nodejs4.3"
+	runtime = "nodejs8.10"
 	filename = "function.zip"
 	source_code_hash = "${base64sha256(file("function.zip"))}"
 	role = "${aws_iam_role.lambda_exec_role.arn}"


### PR DESCRIPTION
nodejs4.3 is no longer supported by AWS Lambda.